### PR TITLE
BUGFIX passowrd reset field

### DIFF
--- a/src/Page/MemberProfileController.php
+++ b/src/Page/MemberProfileController.php
@@ -122,8 +122,10 @@ class MemberProfileController extends \PageController
 
             $fields->push(HiddenField::create('ID')->setValue($member->ID));
 
-            $password = $fields->dataFieldByName('Password');
-            $password->setCanBeEmpty(true);
+
+
+            $fields->replaceField('Password', Security::getCurrentUser()->getMemberPasswordField());
+            //$password->setCanBeEmpty(true);
 
             if ($member->ProfileImage()->exists()) {
                 $src = ' src="'.$member->ProfileImage()->CMSThumbnail()->URL.'"';


### PR DESCRIPTION
fixes #9 

This resolves the validation issue, but I don't feel this is the appropriate fix at this point. Currently I've updated it to reference a method on `Member` that generates the password fields. I'm fairly certain there are CMS react requirements not being pulled in causing parts to fail at this point. We'll likely have to re-construct something frontend friendly from a js standpoint.